### PR TITLE
Fix add_logo memory leak

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -19,7 +19,7 @@ importFrom(dplyr,"pull")
 importFrom(dplyr,"vars")
 importFrom(dplyr,"all_vars")
 
-importFrom(magick, image_read, image_info, image_scale, image_composite, image_write)
+importFrom(magick, image_read, image_info, image_scale, image_composite, image_write, image_destroy)
 importFrom(tools, file_ext)
 
 exportPattern("^[[:alpha:]]+")

--- a/R/quicksave.R
+++ b/R/quicksave.R
@@ -156,6 +156,9 @@ add_logo <- function(file, logo_scale = 0.15, logo_position = "br",
 
   # Overwrite the file with the logo added
   image_write(final_img, path = file)
+
+  image_destroy(img_plot)
+  image_destroy(img_logo)
 }
 
 # Function to preview the image


### PR DESCRIPTION
Memory leak occurred after add_logo had been called many times through quicksave.

Eventually it can lead to the following:
```
Error in eval(expr, p) :
  R: cache resources exhausted `[...]/rcrea/extdata/CREA-logo-simple.svg' @ error/cache.c/OpenPixelCache/4095
```

We explicitly destroy the loaded images to prevent this.